### PR TITLE
Use revised input data

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -23,7 +23,7 @@ javaOptions += "-Xmx8G"
 fork in run := true
 
 libraryDependencies ++= Seq(
-  "com.azavea.geotrellis" %% "geotrellis-spark-etl" % "0.10.0-SNAPSHOT",
+  "com.azavea.geotrellis" %% "geotrellis-spark-etl" % "0.10.1",
   "org.apache.spark" %% "spark-core" % "1.6.0" % "provided",
   "org.scalatest"       %%  "scalatest"      % "2.2.0" % "test"
 )

--- a/emr/run-ingest-step.sh
+++ b/emr/run-ingest-step.sh
@@ -4,9 +4,8 @@ source $DIR/environment.sh
 JAR=$CODE_TARGET/treecanopy-ingest-assembly-0.1.0.jar
 
 DATA_NAME=ned-19
-DST_CRS=EPSG:3857
 SOURCE_BUCKET=azavea-datahub
-SOURCE_PREFIX=raw/treecanopy-2006-2008-pennsylvania-albers-tiled
+SOURCE_PREFIX=raw/treecanopy-2006-2008-pennsylvania-albers
 
 TARGET=
 
@@ -14,7 +13,7 @@ PARTITION_ARG='partitionCount=5000,'
 
 ON_FAILURE=CONTINUE
 
-LAYER_NAME=treecanopy-2006-2008-pa
+LAYER_NAME=treecanopy-2006-2008-pa-revised
 CRS=EPSG:3857
 TILE_SIZE=512
 INGEST_CLASS=treecanopy.Ingest
@@ -27,10 +26,11 @@ TILE_ARGS=${TILE_ARGS},--input,s3,--format,geotiff,-I,"$PARTITION_ARG"bucket=$SO
 TILE_ARGS=${TILE_ARGS},--output,render,-O,path=$TARGET,encoding=png
 TILE_ARGS=${TILE_ARGS},--layer,$LAYER_NAME,--tileSize,$TILE_SIZE,--crs,$CRS
 TILE_ARGS=${TILE_ARGS},--layoutScheme,tms,--cache,NONE,--pyramid
+TILE_ARGS=${TILE_ARGS},--reproject,per-tile  # avoid "Multiple CRS tags found" errors
 
 echo "TILE: $TILE_ARGS"
 
-# http://com.azavea.datahub.tms.s3.amazonaws.com/treecanopy-2006-2008-pa/{z}/{x}/{y}.png
+# http://com.azavea.datahub.tms.s3.amazonaws.com/treecanopy-2006-2008-pa-revised/{z}/{x}/{y}.png
 
 aws emr add-steps --cluster-id $CLUSTER_ID --steps \
   Name=Ingest-$LAYER_NAME,ActionOnFailure=$ON_FAILURE,Type=Spark,Jar=$JAR,Args=[$TILE_ARGS]


### PR DESCRIPTION
@lossyrob, running with an updated dataset my ingest failed. My changes are in this PR.

Setting up the ssh tunnel for the Spark UI failed with Permission denied (publickey) -- do I need different keys than I've been using for azavea-datahub?

``` bash
ssh -i ~/azavea-data.pem -N -D 8157 hadoop@ec2-54-88-174-245.compute-1.amazonaws.com
```

Looking through the logs (https://console.aws.amazon.com/elasticmapreduce/home?region=us-east-1#cluster-details:j-2GSBEQYQAI31Y) I saw this in the stderr of one container. Red herring? After termination and not in any other container logs:

```
16/06/10 14:26:25 INFO DAGScheduler: ResultStage 0 (reduce at TileLayerMetadata.scala:125) finished in 244.422 s
16/06/10 14:26:25 INFO YarnClusterScheduler: Removed TaskSet 0.0, whose tasks have all completed, from pool 
16/06/10 14:26:25 INFO DAGScheduler: Job 0 finished: reduce at TileLayerMetadata.scala:125, took 245.344623 s
16/06/10 14:26:25 INFO SparkUI: Stopped Spark web UI at http://172.31.24.73:41711
16/06/10 14:26:25 INFO YarnClusterSchedulerBackend: Shutting down all executors
16/06/10 14:26:25 INFO YarnClusterSchedulerBackend: Asking each executor to shut down
16/06/10 14:26:25 INFO MapOutputTrackerMasterEndpoint: MapOutputTrackerMasterEndpoint stopped!
16/06/10 14:26:25 INFO MemoryStore: MemoryStore cleared
16/06/10 14:26:25 INFO BlockManager: BlockManager stopped
16/06/10 14:26:25 INFO BlockManagerMaster: BlockManagerMaster stopped
16/06/10 14:26:25 INFO OutputCommitCoordinator$OutputCommitCoordinatorEndpoint: OutputCommitCoordinator stopped!
16/06/10 14:26:25 INFO SparkContext: Successfully stopped SparkContext
16/06/10 14:26:25 INFO RemoteActorRefProvider$RemotingTerminator: Shutting down remote daemon.
16/06/10 14:26:25 ERROR ApplicationMaster: User class threw exception: java.lang.IllegalArgumentException: requirement failed: Multiple CRS tags found: Set(geotrellis.proj4.CRS$$anon$1@9e79869, geotrellis.proj4.CRS$$anon$1@6f44e0a4)
java.lang.IllegalArgumentException: requirement failed: Multiple CRS tags found: Set(geotrellis.proj4.CRS$$anon$1@9e79869, geotrellis.proj4.CRS$$anon$1@6f44e0a4)
    at scala.Predef$.require(Predef.scala:233)
    at geotrellis.spark.TileLayerMetadata$.collectMetadataWithCRS(TileLayerMetadata.scala:136)
    at geotrellis.spark.TileLayerMetadata$.fromRdd(TileLayerMetadata.scala:172)
    at geotrellis.spark.etl.Etl.tile(Etl.scala:134)
    at treecanopy.Ingest$.main(Main.scala:50)
    at treecanopy.Ingest.main(Main.scala)
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:57)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke(Method.java:606)
    at org.apache.spark.deploy.yarn.ApplicationMaster$$anon$2.run(ApplicationMaster.scala:542)
16/06/10 14:26:25 INFO RemoteActorRefProvider$RemotingTerminator: Remote daemon shut down; proceeding with flushing remote transports.
16/06/10 14:26:25 INFO ApplicationMaster: Final app status: FAILED, exitCode: 15, (reason: User class threw exception: java.lang.IllegalArgumentException: requirement failed: Multiple CRS tags found: Set(geotrellis.proj4.CRS$$anon$1@9e79869, geotrellis.proj4.CRS$$anon$1@6f44e0a4))
16/06/10 14:26:25 INFO ShutdownHookManager: Shutdown hook called
16/06/10 14:26:25 INFO ShutdownHookManager: Deleting directory /mnt1/yarn/usercache/hadoop/appcache/application_1465568289716_0001/spark-1158bc3c-1bc5-455e-806d-b560f9d1be00
16/06/10 14:26:25 INFO ShutdownHookManager: Deleting directory /mnt/yarn/usercache/hadoop/appcache/application_1465568289716_0001/spark-ef6cfbca-4216-43cf-aa3c-7d6054f2d4a1
```
