### PR TITLE
Create statewide canopy tiles augmented with local canopy data

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,5 @@
 name := "treecanopy-ingest"
-version := "0.1.0"
+version := "0.2.0"
 scalaVersion := "2.10.5"
 crossScalaVersions := Seq("2.11.5", "2.10.5")
 organization := "com.azavea"
@@ -23,7 +23,7 @@ javaOptions += "-Xmx8G"
 fork in run := true
 
 libraryDependencies ++= Seq(
-  "com.azavea.geotrellis" %% "geotrellis-spark-etl" % "0.10.0-SNAPSHOT",
+  "com.azavea.geotrellis" %% "geotrellis-spark-etl" % "0.10.1",
   "org.apache.spark" %% "spark-core" % "1.6.0" % "provided",
   "org.scalatest"       %%  "scalatest"      % "2.2.0" % "test"
 )

--- a/emr/environment.sh
+++ b/emr/environment.sh
@@ -4,7 +4,7 @@ CODE_TARGET=s3://azavea-datahub/jars/treecanopy-ingest
 AWS_REGION="us-east-1"
 SUBNET_ID="subnet-c5fefdb1"
 
-KEY_NAME=geotrellis-emr
+KEY_NAME=azavea-data
 
 # If you want to have zeppelin, uncomment
 # ZEPPELIN="Name=Zeppelin-Sandbox"
@@ -34,4 +34,4 @@ EXECUTOR_YARN_OVERHEAD=520
 # EXECUTOR_YARN_OVERHEAD=5200
 
 
-CLUSTER_ID=j-KNZE6KB8SY5D
+CLUSTER_ID=j-2QRLH6C75FI5I

--- a/emr/run-ingest-step.sh
+++ b/emr/run-ingest-step.sh
@@ -5,12 +5,14 @@ JAR=$CODE_TARGET/treecanopy-ingest-assembly-0.2.0.jar
 
 ON_FAILURE=CONTINUE
 
+INGEST_CLASS=treecanopy.Ingest
+
 TILE_ARGS="--deploy-mode,cluster"
 TILE_ARGS=${TILE_ARGS},--class,$INGEST_CLASS,--driver-memory,$DRIVER_MEMORY,--executor-memory,$EXECUTOR_MEMORY,--num-executors,$NUM_EXECUTORS,--executor-cores,$EXECUTOR_CORES
 TILE_ARGS=${TILE_ARGS},--conf,spark.yarn.executor.memoryOverhead=$EXECUTOR_YARN_OVERHEAD
 TILE_ARGS=${TILE_ARGS},$JAR
 
-echo "SPARK: $TILE_ARGS"
+echo "TILE: $TILE_ARGS"
 
 aws emr add-steps --cluster-id $CLUSTER_ID --steps \
   Name=Ingest-Tree-Canopy,ActionOnFailure=$ON_FAILURE,Type=Spark,Jar=$JAR,Args=[$TILE_ARGS]

--- a/emr/run-ingest-step.sh
+++ b/emr/run-ingest-step.sh
@@ -1,36 +1,16 @@
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 source $DIR/environment.sh
 
-JAR=$CODE_TARGET/treecanopy-ingest-assembly-0.1.0.jar
-
-DATA_NAME=ned-19
-DST_CRS=EPSG:3857
-SOURCE_BUCKET=azavea-datahub
-SOURCE_PREFIX=raw/treecanopy-2006-2008-pennsylvania-albers-tiled
-
-TARGET=
-
-PARTITION_ARG='partitionCount=5000,'
+JAR=$CODE_TARGET/treecanopy-ingest-assembly-0.2.0.jar
 
 ON_FAILURE=CONTINUE
-
-LAYER_NAME=treecanopy-2006-2008-pa
-CRS=EPSG:3857
-TILE_SIZE=512
-INGEST_CLASS=treecanopy.Ingest
 
 TILE_ARGS="--deploy-mode,cluster"
 TILE_ARGS=${TILE_ARGS},--class,$INGEST_CLASS,--driver-memory,$DRIVER_MEMORY,--executor-memory,$EXECUTOR_MEMORY,--num-executors,$NUM_EXECUTORS,--executor-cores,$EXECUTOR_CORES
 TILE_ARGS=${TILE_ARGS},--conf,spark.yarn.executor.memoryOverhead=$EXECUTOR_YARN_OVERHEAD
 TILE_ARGS=${TILE_ARGS},$JAR
-TILE_ARGS=${TILE_ARGS},--input,s3,--format,geotiff,-I,"$PARTITION_ARG"bucket=$SOURCE_BUCKET,key=$SOURCE_PREFIX
-TILE_ARGS=${TILE_ARGS},--output,render,-O,path=$TARGET,encoding=png
-TILE_ARGS=${TILE_ARGS},--layer,$LAYER_NAME,--tileSize,$TILE_SIZE,--crs,$CRS
-TILE_ARGS=${TILE_ARGS},--layoutScheme,tms,--cache,NONE,--pyramid
 
-echo "TILE: $TILE_ARGS"
-
-# http://com.azavea.datahub.tms.s3.amazonaws.com/treecanopy-2006-2008-pa/{z}/{x}/{y}.png
+echo "SPARK: $TILE_ARGS"
 
 aws emr add-steps --cluster-id $CLUSTER_ID --steps \
-  Name=Ingest-$LAYER_NAME,ActionOnFailure=$ON_FAILURE,Type=Spark,Jar=$JAR,Args=[$TILE_ARGS]
+  Name=Ingest-Tree-Canopy,ActionOnFailure=$ON_FAILURE,Type=Spark,Jar=$JAR,Args=[$TILE_ARGS]

--- a/emr/upload-code.sh
+++ b/emr/upload-code.sh
@@ -2,7 +2,7 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 source $DIR/environment.sh
 
 pushd ../
-aws s3 cp ./target/scala-2.10/treecanopy-ingest-assembly-0.1.0.jar $CODE_TARGET/ --region $AWS_REGION
+aws s3 cp ./target/scala-2.10/treecanopy-ingest-assembly-0.2.0.jar $CODE_TARGET/ --region $AWS_REGION
 popd
 
 aws s3 cp bootstrap-geowave.sh $EMR_TARGET/bootstrap-geowave.sh --region $AWS_REGION

--- a/src/main/scala/treecanopy/Main.scala
+++ b/src/main/scala/treecanopy/Main.scala
@@ -3,70 +3,130 @@ package treecanopy
 import geotrellis.proj4._
 import geotrellis.raster._
 import geotrellis.raster.render._
-import geotrellis.raster.render.png._
 import geotrellis.raster.resample._
 import geotrellis.spark._
-import geotrellis.spark.etl.Etl
-import geotrellis.spark.io._
 import geotrellis.spark.io.s3._
 import geotrellis.spark.pyramid.Pyramid
 import geotrellis.spark.render._
 import geotrellis.spark.tiling._
 import geotrellis.spark.util.SparkUtils
 import geotrellis.vector._
-import geotrellis.vector.io._
 
 import com.amazonaws.services.s3.model._
-import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.mapreduce.Job
 import org.apache.spark._
 import org.apache.spark.rdd.RDD
 
-object Ingest {
-  val targetLayoutScheme =
-    ZoomedLayoutScheme(WebMercator, 512)
 
+object Ingest {
+  val sourceBucket = "azavea-datahub"
+  val statewideLayerName = "raw/treecanopy-2006-2008-pennysylvania-albers"
+  val localLayerNames = List(
+    "raw/treecanopy-pennsylvania-local/abingtons",
+    "raw/treecanopy-pennsylvania-local/alleghenyCounty",
+    "raw/treecanopy-pennsylvania-local/harrisburg",
+    "raw/treecanopy-pennsylvania-local/lancasterCity",
+    "raw/treecanopy-pennsylvania-local/montgomeryCounty",
+    "raw/treecanopy-pennsylvania-local/stateCollege"
+  )
+  val outputPath = "s3://com.azavea.datahub.tms/{name}/{z}/{x}/{y}.png"
+  val outputName = "treecanopy-2006-2008-pa-merged"
+
+  val tileSize = 256
+  val targetLayoutScheme =
+    ZoomedLayoutScheme(WebMercator, tileSize)
+
+  // Map 1 to the canopy color and everything else to 0
   val colorMap =
     ColorMap(
       Map(
         0 -> 0x00000000,
-        1 -> 0x139A68FF
+        1 -> 0x139A68FF,
+        Int.MaxValue -> 0x00000000
       )
     )
 
   def main(args: Array[String]): Unit = {
     implicit val sc = SparkUtils.createSparkContext("Tree Canopy ETL", new SparkConf(true))
 
+    val maxLocalZoom = 19  // highest zoom level of local datasets
+    val partitioner = new HashPartitioner(5000)
+
+
     try {
+      val statewideLevelStream = loadAndTile(statewideLayerName, partitioner, maxLocalZoom)
 
-      println(args.toSeq)
-      val etl = Etl(args)
+      val localLevelStreams = localLayerNames.map(localLayerName => {
+        loadAndTile(localLayerName, partitioner, maxLocalZoom)
+      })
 
-      val sourceTiles =
-        etl.load[ProjectedExtent, Tile]
+      foreach [(Int, RDD[(SpatialKey, Tile)] with Metadata[TileLayerMetadata[SpatialKey]]), Any
+        ] (statewideLevelStream, localLevelStreams, {case ((z, statewide), localLevels) =>
 
-      // Reproject and tile the layer.
-      val (zoom, canopy) =
-        etl.tile(sourceTiles)
+        val locals = localLevels.map({ case (_, local) => local})
+        val merged =
+          locals.foldLeft(statewide) { (acc, local) =>
+            // merge() will add statewide values only where the local value is absent or NODATA
+            local.merge(acc)
+          }
 
-      val conf = etl.conf
-      val path = "s3://com.azavea.datahub.tms/{name}/{z}/{x}/{y}.png"
+        val layerId = LayerId(outputName, z)
+        val keyToPath = SaveToS3.spatialKeyToPath(layerId, outputPath)
 
-      Pyramid.levelStream(canopy, targetLayoutScheme, zoom, NearestNeighbor)
-        .foreach { case (z, layer) =>
-          val layerId = LayerId(conf.layerName(), z)
-          val keyToPath = SaveToS3.spatialKeyToPath(layerId, path)
+        // Color the tiles by the color map and save to S3
+        merged
+          .renderPng(colorMap)
+          .mapValues(_.bytes)
+          .saveToS3(keyToPath, { putObject =>
+            putObject.withCannedAcl(CannedAccessControlList.PublicRead)
+          })
+      })
 
-          // Color the tiles by the color map and save to S3
-          layer
-            .renderPng(colorMap)
-            .mapValues(_.bytes)
-            .saveToS3(keyToPath, { putObject =>
-              putObject.withCannedAcl(CannedAccessControlList.PublicRead)
-            })
-        }
     } finally {
       sc.stop()
     }
   }
+
+  // Apply a function to statewide and local data for each level of a pyramid stream
+  def foreach[A, B](statewide: Stream[A], locals: List[Stream[A]], f: (A, List[A]) => B) {
+    if (statewide.nonEmpty) {
+      f(statewide.head, locals.map(_.head))
+      foreach(statewide.tail, locals.map(_.tail), f)
+    }
+  }
+
+  // Load and tile a dataset, resampling to specified max zoom and returning a pyramid level stream
+  def loadAndTile(rawName: String, partitioner: Partitioner, maxZoom: Int)
+                 (implicit sc: SparkContext)
+                 : Stream[(Int, RDD[(SpatialKey, Tile)] with Metadata[TileLayerMetadata[SpatialKey]])] = {
+    val raw = loadFromS3(sourceBucket, rawName, partitioner.numPartitions)
+    val (myMaxZoom, tiled) = tile(raw, tileSize, NearestNeighbor, partitioner)
+    val resampled =
+      if (myMaxZoom >= maxZoom) {
+        tiled
+      } else {
+        tiled.resampleToZoom(myMaxZoom, maxZoom, NearestNeighbor)
+      }
+    Pyramid.levelStream(resampled, targetLayoutScheme, maxZoom, NearestNeighbor)
+  }
+
+  def loadFromS3(bucket: String, prefix: String, partitionCount: Int)(implicit sc: SparkContext): RDD[(ProjectedExtent, Tile)] = {
+    val conf = {
+      val job = Job.getInstance(sc.hadoopConfiguration)
+      S3InputFormat.setBucket(job, bucket)
+      S3InputFormat.setPrefix(job, prefix)
+      S3InputFormat.setPartitionCount(job, partitionCount)
+      job.getConfiguration
+    }
+
+    sc.newAPIHadoopRDD(conf, classOf[GeoTiffS3InputFormat], classOf[ProjectedExtent], classOf[Tile])
+  }
+
+  def tile(rdd: RDD[(ProjectedExtent, Tile)], tileSize: Int, method: ResampleMethod, partitioner: Partitioner): (Int, TileLayerRDD[SpatialKey]) = {
+    val (_, md) = TileLayerMetadata.fromRdd(rdd, FloatingLayoutScheme(tileSize))
+    val tilerOptions = Tiler.Options(resampleMethod = method, partitioner = partitioner)
+    val tiled = ContextRDD(rdd.tileToLayout[SpatialKey](md, tilerOptions), md)
+    tiled.reproject(WebMercator, ZoomedLayoutScheme(WebMercator, tileSize), method)
+  }
+
 }


### PR DESCRIPTION
- Load statewide canopy raster and 6 local canopy rasters
- Load directly rather than using built-in ETL (ETL control is cumbersome with multiple datasets in the same job)
- Resample all rasters to zoom 19 (the max zoom of the local rasters)
- Use tile size 256 (because of https://github.com/geotrellis/geotrellis/issues/1550)
- Merge statewide and local data, with local taking precedence
